### PR TITLE
[#3] Handle exception cleaning better

### DIFF
--- a/classes/api.php
+++ b/classes/api.php
@@ -23,7 +23,11 @@ use GuzzleHttp\Promise\Utils;
 use GuzzleHttp\Psr7\Request;
 use Psr\Http\Message\StreamInterface;
 use coding_exception;
+use Exception;
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
+use Throwable;
 
 /**
  * Azure blob storage API.
@@ -78,6 +82,7 @@ class api {
      * @param string $container Azure storage container name (inside the given storage account).
      * @param string $sastoken SAS (Shared access secret) token for authentication.
      * @param bool $redactsastoken If should react SAS token from error messages to avoid accidental leakage.
+     * Disabling this will likely leak your SAS token as part of error messages.
      */
     public function __construct(
         /** @var string Azure storage account name */
@@ -86,7 +91,8 @@ class api {
         public string $container,
         /** @var string SAS token for authentication */
         public string $sastoken,
-        /** @var bool If should redact SAS token from error messages to avoid accidental leakage */
+        /** @var bool If should redact SAS token from error messages to avoid accidental leakage.
+         * Disabling this will likely leak your SAS token as part of error messages. */
         public bool $redactsastoken = true
     ) {
         $this->client = new Client();
@@ -138,7 +144,7 @@ class api {
     public function get_blob_async(string $key): PromiseInterface {
         // Enable streaming response, useful for large files e.g. videos.
         return $this->client->getAsync($this->build_blob_url($key), ['stream' => true])
-            ->then(null, $this->clean_exception_sas_if_needed());
+            ->then(null, $this->rethrow_cleaned_exception_if_needed());
     }
 
     /**
@@ -147,7 +153,7 @@ class api {
      * @return PromiseInterface Promise that resolves a ResponseInterface value where the properties are in the response headers.
      */
     public function get_blob_properties_async(string $key): PromiseInterface {
-        return $this->client->headAsync($this->build_blob_url($key))->then(null, $this->clean_exception_sas_if_needed());
+        return $this->client->headAsync($this->build_blob_url($key))->then(null, $this->rethrow_cleaned_exception_if_needed());
     }
 
     /**
@@ -156,7 +162,7 @@ class api {
      * @return PromiseInterface Promise that resolves once the delete request succeeds.
      */
     public function delete_blob_async(string $key): PromiseInterface {
-        return $this->client->deleteAsync($this->build_blob_url($key))->then(null, $this->clean_exception_sas_if_needed());
+        return $this->client->deleteAsync($this->build_blob_url($key))->then(null, $this->rethrow_cleaned_exception_if_needed());
     }
 
     /**
@@ -199,7 +205,7 @@ class api {
                 ],
                 'body' => $contentstream,
             ]
-        )->then(null, $this->clean_exception_sas_if_needed());
+        )->then(null, $this->rethrow_cleaned_exception_if_needed());
     }
 
     /**
@@ -242,7 +248,7 @@ class api {
                 );
 
                 $request = new Request('PUT', $this->build_blob_block_url($key, $blockid), ['content-md5' => $blockmd5], $content);
-                $promises[] = $this->client->sendAsync($request)->then(null, $this->clean_exception_sas_if_needed());
+                $promises[] = $this->client->sendAsync($request)->then(null, $this->rethrow_cleaned_exception_if_needed());
                 $blockids[] = $blockid;
             };
 
@@ -258,14 +264,14 @@ class api {
             $bodymd5 = base64_encode(hex2bin(md5($body)));
             $request = new Request('PUT', $this->build_blocklist_url($key),
                 ['Content-Type' => 'application/xml', 'content-md5' => $bodymd5], $body);
-            $this->client->sendAsync($request)->then(null, $this->clean_exception_sas_if_needed())->wait();
+            $this->client->sendAsync($request)->then(null, $this->rethrow_cleaned_exception_if_needed())->wait();
 
             // Now it is combined, set the md5 and content type on the completed blob.
             $request = new Request('PUT', $this->build_blob_properties_url($key), [
                 'x-ms-blob-content-md5' => base64_encode($md5),
                 'x-ms-blob-content-type' => $contenttype,
             ]);
-            $this->client->sendAsync($request)->then(null, $this->clean_exception_sas_if_needed())->wait();
+            $this->client->sendAsync($request)->then(null, $this->rethrow_cleaned_exception_if_needed())->wait();
 
             // Done, resolve the entire promise.
             $entirepromise->resolve('fulfilled');
@@ -301,17 +307,41 @@ class api {
     }
 
     /**
-     * Returns a request exception handling function that redacts the SAS token from error messages if needed.
+     * Returns a request exception handling function that redacts the exception message.
+     * This is necessary to redact the SAS token and the container URL.
+     *
      * @return callable
      */
-    private function clean_exception_sas_if_needed(): callable {
-        return function(RequestException $ex) {
-            if ($this->redactsastoken) {
-                $newmsg = str_replace($this->sastoken, '[SAS TOKEN REDACTED]', $ex->getMessage());
-                $exceptiontype = get_class($ex);
-                throw new $exceptiontype($newmsg, $ex->getRequest(), $ex->getResponse(), $ex, $ex->getHandlerContext());
+    private function rethrow_cleaned_exception_if_needed(): callable {
+        // Note this MUST accept a generic throwable,
+        // as it must respond to any exceptions thrown by Guzzle.
+        return function(Throwable $ex) {
+            // If disabled don't do anything, just re-throw.
+            if (!$this->redactsastoken) {
+                throw $ex;
             }
-            throw $ex;
+
+            // Grab status code from exception if it defines one,
+            // this should be safe to share and would help in debugging any unexpected
+            // exceptions.
+            $errormessage = method_exists($ex, "getResponse") && !empty($ex->getResponse())
+                ? 'Connection failed with status code ' . $ex->getResponse()->getStatusCode()
+                : 'Unknown error thrown by Guzzle';
+
+            // We want to keep the original class but modify the message.
+            // It's important we keep the same exception class as the API relies on this to tell what went wrong.
+            // There doesn't appear to be an easier way to do this :( .
+            switch (get_class($ex)) {
+                case ClientException::class:
+                    throw new ClientException($errormessage, $ex->getRequest(), $ex->getResponse());
+                case RequestException::class:
+                    throw new RequestException($errormessage, $ex->getRequest(), $ex->getRequest());
+                case ConnectException::class:
+                    throw new ConnectException($errormessage, $ex->getRequest());
+                // Be super safe, if this falls throw just throw a generic message.
+                default:
+                    throw new Exception($errormessage, $ex->getCode(), $ex);
+            }
         };
     }
 


### PR DESCRIPTION
Closes #3 

Issue above arises from a different exception being thrown than the callback handles, leading to the error. I've fixed this but also expanded upon the cleaning to make it way more safe as the ramifications of leaking the SAS token are huge.

**Changes**
- This fixes the way exceptions are cleaned.
    - Exceptions need to be cleaned very carefully as Guzzle by default outputs the URL which includes the SAS token (essentially if this happens you are screwed, users can access your data and you need to roll your token ASAP!)
    - But we want to maintain the original exception as code in other places depends on catching a specific exception which breaks if we chain it to a generic exception.

(Note from my reading of the Azure docs the SAS token MUST be a url param and cannot be a header instead :cry: )

**Testing**
- I tested this on my local azure storage setup, exceptions now look like this which is IMO a good balance of info (status code) but without leaking any sensitive credentials.

![image](https://github.com/user-attachments/assets/28cda238-8b5b-4f44-991a-4426113afea3)
